### PR TITLE
i have an idea why not update  client-side files that uses Router.pus…

### DIFF
--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-import { useRouter } from 'next/navigation';
+// useRouter is no longer needed for the primary redirect
 import Link from 'next/link';
 import { ChromeIcon } from 'lucide-react';
 
@@ -29,7 +29,6 @@ const formSchema = z.object({
 });
 
 export function SignInForm() {
-  const router = useRouter();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = React.useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = React.useState(false);
@@ -61,8 +60,9 @@ export function SignInForm() {
         title: 'Sign In Successful',
         description: 'Welcome back! Redirecting to dashboard...',
       });
-      router.push('/dashboard');
-      router.refresh(); // Important to refresh server components and re-evaluate auth state
+      // Changed to window.location.href
+      window.location.href = "/dashboard";
+      // router.refresh(); // No longer needed with full page reload
     }
   }
 
@@ -71,12 +71,13 @@ export function SignInForm() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`, // Changed to /auth/callback
+        redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
-    setIsGoogleLoading(false);
+    // setIsGoogleLoading(false); // Keep loading state until redirect happens
 
     if (error) {
+      setIsGoogleLoading(false); // Reset loading if error occurs before redirect
       toast({
         title: 'Google Sign-In Failed',
         description: error.message,

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-import { useRouter } from 'next/navigation';
+// useRouter is no longer needed for the primary redirect
 import Link from 'next/link';
 import { ChromeIcon } from 'lucide-react';
 
@@ -29,7 +29,6 @@ const formSchema = z.object({
 });
 
 export function SignUpForm() {
-  const router = useRouter();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = React.useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = React.useState(false);
@@ -48,7 +47,7 @@ export function SignUpForm() {
       email: values.email,
       password: values.password,
       options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`, // Changed to /auth/callback
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
       },
     });
     
@@ -96,22 +95,21 @@ export function SignUpForm() {
       setIsLoading(false); 
 
       if (data.user.identities && data.user.identities.length === 0 && !data.session) {
-        // This case typically indicates the email is already registered but not confirmed with the current provider (e.g. email/pass)
-        // Or if email confirmation is required and it's the first time.
         toast({
           title: 'Confirmation Required or Email Exists',
           description: 'Please check your email for a confirmation link. If already registered, try signing in.',
           variant: 'default',
           duration: 10000,
         });
-      } else if (data.session) { // User is immediately active (e.g., auto-confirm is on, or social login that doesn't need email confirm)
+      } else if (data.session) { 
         toast({
           title: 'Sign Up Successful',
           description: 'Welcome! Redirecting to dashboard...',
         });
-        router.push('/dashboard');
-        router.refresh();
-      } else if (data.user && !data.session) { // Standard email confirmation flow
+        // Changed to window.location.href
+        window.location.href = "/dashboard";
+        // router.refresh(); // No longer needed with full page reload
+      } else if (data.user && !data.session) { 
          toast({
           title: 'Sign Up Successful!',
           description: 'Please check your email to confirm your account.',
@@ -133,12 +131,13 @@ export function SignUpForm() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`, // Changed to /auth/callback
+        redirectTo: `${window.location.origin}/auth/callback`,
       },
     });
-    setIsGoogleLoading(false); 
+    // setIsGoogleLoading(false); // Keep loading state until redirect happens
 
     if (error) {
+      setIsGoogleLoading(false); // Reset loading if error occurs before redirect
       toast({
         title: 'Google Sign-Up Failed',
         description: error.message,


### PR DESCRIPTION
…h('/dashboard') to window.location.href = "/dashboard"

I found two client-side files in my project where Router.push('/dashboard') is used:

1. [src/components/auth/sign-in-form.tsx]
2. [src/components/auth/sign-up-form.tsx]

To update them:

- Replace:

  router.push('/dashboard'); router.refresh();

- With:

  window.location.href = "/dashboard"; // Remove router.refresh(); as it's not needed with a full reload.

This change will force a full page reload when redirecting to the dashboard after sign-in or sign-up.